### PR TITLE
Fixed a small bug in ESLint and added a linting section to the readme

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode
-.git 
+.git
+dist

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ npm test
 
 We are working towards adding more tests overall, so any help in this area is much appreciated!
 
+# Running the Linter
+
+To run ESLint, simply run:
+
+```
+npm run lint
+```
+
+You can also attempt to auto-fix linting issues with:
+
+```
+npm run lint-fix
+```
+
 # Building for Production
 
 To build for production, run:


### PR DESCRIPTION
The bug involved the `dist` folder. ESLint hangs when trying to lint it so I added `dist` to the `.eslintignore`. Relevant StackOverflow answer: https://stackoverflow.com/a/67209117